### PR TITLE
Add `sourceRef` option to the parsers and pass it through `TaskObject`

### DIFF
--- a/TaskObject.js
+++ b/TaskObject.js
@@ -6,6 +6,27 @@ const addItemToMapArrayValue = (map, key, item) => {
 }
 
 export default class TaskObject {
+  /** @type {Map<string, ApiAsset>} */
+  #assetNameMap
+
+  /** @type {Map<string, ApiAsset[]} */
+  #cklHostnameMap
+  
+  /** @type {Map<string, string[]} */
+  #benchmarkIdMap
+
+  /** @type {ParseResult[]} */
+  parsedResults
+
+  /** @type {ApiAsset[]} */
+  apiAssets
+
+  /** @type {ApiStig[]} */
+  apiStigs
+
+  /** @type {any[]} */
+  sourceRefs
+
   /**
    * @param {Object} TaskObjectParam
    * @param {ApiAsset[]} TaskObjectParam.apiAssets
@@ -15,28 +36,23 @@ export default class TaskObject {
    */
   constructor({ apiAssets = [], apiStigs = [], parsedResults = [], options = {} }) {
     // An array of results from the parsers
-    /** @type {ParseResult[]} */
     this.parsedResults = parsedResults
-
     // An array of assets from the API
-    /** @type {ApiAsset[]} */
     this.apiAssets = apiAssets
-
     // Create Map for the assets, key:apiAsset.name, value: apiAsset
-    /** @type {Map<string, ApiAsset>} */
-    this.mappedAssetNames = new Map()
-
+    this.#assetNameMap = new Map()
     // Create Map for the cklHostnames, key:apiAsset.metadata.cklHostName, value:apiAsset[]
-    /** @type {Map<string, ApiAsset[]} */
-    this.mappedCklHostnames = new Map()
+    this.#cklHostnameMap = new Map()
+    // An array of any parseResult.sourceRef
+    this.sourceRefs = parsedResults.filter( parseResult => parseResult.sourceRef !== undefined )
 
     for (const apiAsset of apiAssets) {
       // Change apiAsset.stigs from an array of stig objects to an array of benchmarkId strings
       apiAsset.stigs = apiAsset.stigs.map(stig => stig.benchmarkId)
-      this.mappedAssetNames.set(apiAsset.name.toLowerCase(), apiAsset)
+      this.#assetNameMap.set(apiAsset.name.toLowerCase(), apiAsset)
       if (apiAsset.metadata?.cklHostName) {
         addItemToMapArrayValue(
-          this.mappedCklHostnames, 
+          this.#cklHostnameMap, 
           apiAsset.metadata.cklHostName.toLowerCase(), 
           apiAsset
         )
@@ -45,23 +61,23 @@ export default class TaskObject {
 
     // A Map() of the installed benchmarkIds return by the API
     // key: benchmarkId, value: array of revisionStr
-    this.mappedStigs = new Map(apiStigs.map(stig => [stig.benchmarkId, stig.revisionStrs]))
+    this.#benchmarkIdMap = new Map(apiStigs.map(stig => [stig.benchmarkId, stig.revisionStrs]))
 
     // An array of accumulated errors
     this.errors = []
 
     // A Map() of assets to be processed by the writer
-    this.taskAssets = this._createTaskAssets(options)
+    this.taskAssets = this.#createTaskAssets(options)
   }
 
-  _findAssetFromParsedTarget(target) {
+  #findAssetFromParsedTarget(target) {
     // If there's no target.metadata.cklHostName, return the apiAsset (if any) matching the target.name
     if (!target.metadata.cklHostName) {
-      return this.mappedAssetNames.get(target.name.toLowerCase())
+      return this.#assetNameMap.get(target.name.toLowerCase())
     }
 
     // get the array of apiAssets (if any) having the given target.metadata.cklHostName
-    const matchedByCklHostname = this.mappedCklHostnames.get(target.metadata.cklHostName.toLowerCase())
+    const matchedByCklHostname = this.#cklHostnameMap.get(target.metadata.cklHostName.toLowerCase())
     // return null if no matches
     if (!matchedByCklHostname) return null
     
@@ -73,7 +89,7 @@ export default class TaskObject {
     return matchedByAllCklMetadata
   }
 
-  _createTaskAssets(options) {
+  #createTaskAssets(options) {
     // taskAssets is a Map() keyed by lowercase asset name (or CKL metadata), the value is an object:
     // {
     // knownAsset: false, // does the asset need to be created
@@ -100,17 +116,18 @@ export default class TaskObject {
       }
 
       // Try to find the asset in apiAssets
-      const apiAsset = this._findAssetFromParsedTarget(parsedResult.target)
+      const apiAsset = this.#findAssetFromParsedTarget(parsedResult.target)
       if (!apiAsset && !options.createObjects) {
         // Bail if the asset doesn't exist and we shouldn't create it
         this.errors.push({
-          file: parsedResult.file,
-          message: `asset does not exist for target`,
-          target: parsedResult.target
+          message: `asset does not exist for target and createObjects is false`,
+          target: parsedResult.target,
+          sourceRef: parsedResult.sourceRef
         })
         continue
       }
       // Try to find the target in our Map()
+      /** @type {TaskAssetValue} */
       let taskAsset = taskAssets.get(mapKey)
 
       if (!taskAsset) {
@@ -122,7 +139,7 @@ export default class TaskObject {
           newAssignments: [],
           checklists: new Map(), // the vetted result checklists
           checklistsIgnored: [], // the ignored checklists
-          reviews: [] // the vetted reviews
+          sourceRefs: [] // the sourceRefs from each parsedResult for this Asset
         }
         if (!apiAsset) {
           // The asset does not exist in the API. Set assetProps from this parseResult.
@@ -141,10 +158,12 @@ export default class TaskObject {
         // Insert the asset into taskAssets
         taskAssets.set(mapKey, taskAsset)
       }
+      // add any parsedResult.sourceRef to this asset's sourceRefs
+      parsedResult.sourceRef !== undefined && taskAsset.sourceRefs.push(parsedResult.sourceRef)
 
       // Helper functions
       const stigIsInstalled = ({ benchmarkId, revisionStr }) => {
-        const revisionStrs = this.mappedStigs.get(benchmarkId)
+        const revisionStrs = this.#benchmarkIdMap.get(benchmarkId)
         if (revisionStrs) {
           return revisionStr && options.strictRevisionCheck ? revisionStrs.includes(revisionStr) : true
         }
@@ -164,29 +183,17 @@ export default class TaskObject {
       }
       const stigIsNewlyAssigned = (benchmarkId) => taskAsset.newAssignments.includes(benchmarkId)
 
-      const addToTaskAssetChecklistMapArray = (taskAsset, checklist) => {
-        let checklistArray = taskAsset.checklists.get(checklist.benchmarkId)
-        if (checklistArray) {
-          checklistArray.push(checklist)
-        }
-        else {
-          taskAsset.checklists.set(checklist.benchmarkId, [checklist])
-        }
-      }
-
-
       // Vet the checklists in this parseResult 
       for (const checklist of parsedResult.checklists) {
-        checklist.file = parsedResult.file
         if (stigIsInstalled(checklist)) {
           if (stigIsAssigned(checklist)) {
             checklist.newAssignment = stigIsNewlyAssigned(checklist.benchmarkId)
-            addToTaskAssetChecklistMapArray(taskAsset, checklist)
+            addItemToMapArrayValue(taskAsset.checklists, checklist.benchmarkId, checklist)
           }
           else if (options.createObjects) {
             assignStig(checklist.benchmarkId)
             checklist.newAssignment = true
-            addToTaskAssetChecklistMapArray(taskAsset, checklist)
+            addItemToMapArrayValue(taskAsset.checklists, checklist.benchmarkId, checklist)
           }
           else {
             checklist.ignored = `Not mapped to Asset and I can't change that`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,149 @@
 declare module 'stig-manager-client-modules';
 
+interface ApiCollectionBasic {
+    collectionId: string;
+    name: string;
+}
+interface ApiCollectionStig {
+    benchmarkId: string;
+    revisionStr: string;
+    benchmarkDate: string;
+    revisionPinned: boolean;
+    ruleCount: number;
+}
+interface ApiAsset {
+    assetId?: string;
+    name: string;
+    fqdn: string;
+    description: string;
+    ip: string;
+    mac: string;
+    noncomputing: boolean;
+    metadata: Object;
+    collection: ApiCollectionBasic;
+    labelIds: string[];
+    stigs: ApiCollectionStig[] | string[];
+}
+interface ApiStig {
+    benchmarkId: string;
+    revisionStr: string;
+    version: string;
+    release: string;
+    benchmarkDate: string;
+    status: string;
+    statusDate: string;
+    ruleCount: string;
+    collectionIds: string[];
+}
+
+interface ParsedTarget {
+    description: string;
+    fqdn: string;
+    ip: string;
+    mac: string;
+    metadata: Object; 
+    name: string;
+    noncomputing: boolean;
+}
+
+interface ResultEngine {
+    checkContent?: ResultEngineCheckContent;
+    overrides?: ResultEngineOverride[]
+    product: string;
+    time?: string /* date-time */;
+    type: ResultEngineType;
+    version?: string
+}
+
+type ReviewResult = 'pass' | 'fail' | 'notapplicable' | 'notchecked' | 'unknown' | 'error' | 'notselected' | 'informational' | 'fixed';
+type ReviewStatus = 'saved' | 'submitted' | 'accepted' | 'rejected' | null;
+type ResultEngineType = 'scap' | 'script' | 'other';
+interface ResultEngineCheckContent {
+    component: string;
+    location: string;
+}
+interface ResultEngineOverride {
+    authority: string;
+    newResult: ReviewResult;
+    oldResult: ReviewResult;
+    remark?: string;
+    time?: string /* date-time */;
+}
+interface ParsedReview {
+    comment: string;
+    detail: string;
+    result: ReviewResult;
+    resultEngine: ResultEngine | null
+    ruleId: string;
+    status: ReviewStatus;
+}
+
+interface ParsedChecklistStats {
+    error: number;
+    fail: number;
+    fixed: number;
+    informational: number;
+    notapplicable: number;
+    notchecked: number;
+    noselected: number;
+    pass: number;
+    unknown: number;
+}
+
+interface ParsedChecklist {
+    benchmarkId: string;
+    reviews: ParsedReview[];
+    revisionStr: string;
+    stats: ParsedChecklistStats;
+}
+
+interface ParseResult {
+    target: ParsedTarget;
+    checklists: ParsedChecklist[];
+}
+
+interface TaskObjectOptions {
+    createObjects: boolean;
+    collectionId: string;
+    strictRevisionCheck: boolean;
+    [key: string]: any;
+}
+
+interface TaskObjectParseResult extends ParseResult {
+    file: string;
+}
+
+interface TaskObjectParams {
+    apiAssets: ApiAsset[],
+    apiStigs: ApiStig[],
+    parsedResults: TaskObjectParseResult[],
+    options: TaskObjectOptions
+}
+
+interface TaskAssetChecklist extends ParsedChecklist {
+    file: string;
+    newAssignment: boolean;
+    ignored?: boolean;
+}
+
+interface TaskAssetValue {
+    assetProps: ApiAsset;
+    checklists: Map<string, TaskAssetChecklist[]>;
+    checklistsIgnored: TaskAssetChecklist[];
+    hasNewAssignment: boolean;
+    knownAsset: boolean;
+    newAssignments: string[];
+    reviews: ParsedReview[];
+}
+
+declare class TaskObject {
+    constructor (options: TaskObjectParams);
+    apiAssets: ApiAsset[];
+    errors: array;
+    mappedAssetNames: Map<string, ApiAsset>;
+    mappedCklHostnames: Map<string, ApiAsset[]>;
+    mappedStigs: Map<string, string[]>
+    parsedResults: TaskObjectParseResult[];
+    taskAssets: Map<string, TaskAssetValue>;
+
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,11 +95,13 @@ interface ParsedChecklist {
     reviews: ParsedReview[];
     revisionStr: string;
     stats: ParsedChecklistStats;
+    sourceRef: any;
 }
 
 interface ParseResult {
     target: ParsedTarget;
     checklists: ParsedChecklist[];
+    sourceRef: any;
 }
 
 interface TaskObjectOptions {
@@ -121,7 +123,6 @@ interface TaskObjectParams {
 }
 
 interface TaskAssetChecklist extends ParsedChecklist {
-    file: string;
     newAssignment: boolean;
     ignored?: boolean;
 }
@@ -133,17 +134,18 @@ interface TaskAssetValue {
     hasNewAssignment: boolean;
     knownAsset: boolean;
     newAssignments: string[];
-    reviews: ParsedReview[];
+    sourceRefs: any[];
 }
 
 declare class TaskObject {
     constructor (options: TaskObjectParams);
     apiAssets: ApiAsset[];
+    apiStigs: ApiStig[];
+    #assetNameMap: Map<string, ApiAsset>;
+    #benchmarkIdMap: Map<string, string[]>;
+    #cklHostnameMap: Map<string, ApiAsset[]>;
     errors: array;
-    mappedAssetNames: Map<string, ApiAsset>;
-    mappedCklHostnames: Map<string, ApiAsset[]>;
-    mappedStigs: Map<string, string[]>
     parsedResults: TaskObjectParseResult[];
+    sourceRefs: any[];
     taskAssets: Map<string, TaskAssetValue>;
-
 }


### PR DESCRIPTION
- Adds the `sourceRef` property as an option when calling the parsers, and includes the property in the returned object and in each checklist
-  `TaskObject.sourceRefs` provides an array of the `sourceRef`s taken from each `parseResult`.
-  Each `TaskObject.taskAsset` provides an array of the `sourceRef`s taken from each `parseResult` for a given Asset.

Also addressed multiple SonarCloud findings and added JSDoc and index.d.ts type definitions for most of `TaskObject` and much of the parsers.
