### PR TITLE
feat: workaround STIG Viewer 3.2 ruleId abnormalities

### DIFF
--- a/ReviewParser.js
+++ b/ReviewParser.js
@@ -293,7 +293,7 @@ export function reviewsFromCkl(
         if (!stigDatum.ATTRIBUTE_DATA) {
           return false
         }
-        ruleId = stigDatum.ATTRIBUTE_DATA?.endsWith('_rule') ? stigDatum.ATTRIBUTE_DATA : stigDatum.ATTRIBUTE_DATA + '_rule'
+        ruleId = stigDatum.ATTRIBUTE_DATA.endsWith('_rule') ? stigDatum.ATTRIBUTE_DATA : stigDatum.ATTRIBUTE_DATA + '_rule'
         return true
       }
     })

--- a/ReviewParser.js
+++ b/ReviewParser.js
@@ -277,7 +277,10 @@ export function reviewsFromCkl(
     let ruleId
     vuln.STIG_DATA.some(stigDatum => {
       if (stigDatum.VULN_ATTRIBUTE == "Rule_ID") {
-        ruleId = stigDatum.ATTRIBUTE_DATA
+        if (!stigDatum.ATTRIBUTE_DATA) {
+          return false
+        }
+        ruleId = stigDatum.ATTRIBUTE_DATA?.endsWith('_rule') ? stigDatum.ATTRIBUTE_DATA : stigDatum.ATTRIBUTE_DATA + '_rule'
         return true
       }
     })
@@ -861,8 +864,9 @@ export function reviewsFromCklb(
   function generateReview(rule, evalStigResultEngine) {
     let result = resultMap[rule.status]
     if (!result) return
-    const ruleId = rule.rule_id_src
+    let ruleId = rule.rule_id_src ?? rule.rule_id
     if (!ruleId) return
+    ruleId = ruleId.endsWith('_rule') ? ruleId : ruleId + '_rule'
 
     const hasComments = !!rule.finding_details || !!rule.comments
 


### PR DESCRIPTION
missing _rule suffix in .ckl and .cklb
missing rule_id_src in .cklb
[rule_id-test-files.zip](https://github.com/NUWCDIVNPT/stig-manager-client-modules/files/14426964/rule_id-test-files.zip)
