### PR TITLE
Chore: Update github actions to v4

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -24,17 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js 
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: '20.x'
     - name: Install app dependencies
       run: npm ci
     - name: Run tests
       run: npm test
     - name: Upload coverage to github
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: coverage

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
         - main
+        - update-actions
     paths:
         - "ReviewParser.js"
         - "TaskObject.js"
@@ -13,6 +14,7 @@ on:
   pull_request:
     branches:
         - main
+        - update-actions
     paths:
         - "ReviewParser.js"
         - "TaskObject.js"

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -11,6 +11,7 @@ on:
         - "TaskObject.js"
         - "test/**"
         - "WATCHER-test-files/**"
+        - '.github/workflows/unit-testing.yml'
   pull_request:
     branches:
         - main
@@ -20,7 +21,7 @@ on:
         - "TaskObject.js"
         - "test/**"
         - "WATCHER-test-files/**"
-
+        - '.github/workflows/unit-testing.yml'
 jobs:
   build_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
         - main
-        - update-actions
     paths:
         - "ReviewParser.js"
         - "TaskObject.js"
@@ -15,7 +14,6 @@ on:
   pull_request:
     branches:
         - main
-        - update-actions
     paths:
         - "ReviewParser.js"
         - "TaskObject.js"


### PR DESCRIPTION
This pull request upgrades the Node.js version for actions within this repository to Node.js 20. Additionally, it modifies the workflow by incorporating unit-testing.yml into the 'on:' trigger, ensuring the workflow initiates whenever there are updates to it.

The following actions were changed to version 4: 
- actions/checkout
- actions/upload-artifact
- actions/setup-node