### PR TITLE
chore: 1.4.2 release updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nuwcdivnpt/stig-manager-client-modules",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nuwcdivnpt/stig-manager-client-modules",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuwcdivnpt/stig-manager-client-modules",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Truncate long string values to conform with STIGMan OAS.
Error on Asset name too long.