### PR TITLE
fix: correctly parses version of stig that reflects revisionStr.

### DIFF
--- a/ReviewParser.js
+++ b/ReviewParser.js
@@ -932,7 +932,7 @@ export function reviewsFromCklb(
       const checklist = { sourceRef }
       checklist.benchmarkId = typeof stig?.stig_id === 'string' ? stig.stig_id.replace('xccdf_mil.disa.stig_benchmark_', '') : ''
       checklist.benchmarkId = truncateString(checklist.benchmarkId, 255)
-      const stigVersion = stig.version
+      const stigVersion = stig.version ?? '0'
       const stigRelease = typeof stig?.release_info === 'string' ? stig.release_info.match(/Release:\s*(.+?)\s/)?.[1] : ''
       checklist.revisionStr = checklist.benchmarkId && stigRelease ? `V${stigVersion}R${stigRelease}` : null
 

--- a/ReviewParser.js
+++ b/ReviewParser.js
@@ -932,7 +932,7 @@ export function reviewsFromCklb(
       const checklist = { sourceRef }
       checklist.benchmarkId = typeof stig?.stig_id === 'string' ? stig.stig_id.replace('xccdf_mil.disa.stig_benchmark_', '') : ''
       checklist.benchmarkId = truncateString(checklist.benchmarkId, 255)
-      const stigVersion = '0'
+      const stigVersion = stig.version
       const stigRelease = typeof stig?.release_info === 'string' ? stig.release_info.match(/Release:\s*(.+?)\s/)?.[1] : ''
       checklist.revisionStr = checklist.benchmarkId && stigRelease ? `V${stigVersion}R${stigRelease}` : null
 

--- a/test/cklb-tests/CKLBReviewParserChecklistArray.test.js
+++ b/test/cklb-tests/CKLBReviewParserChecklistArray.test.js
@@ -59,7 +59,7 @@ describe('CKLB Checklist tests', () => {
     expect(review.checklists).to.be.an('array')
     expect(review.checklists.length).to.equal(1)
     expect(review.checklists[0].benchmarkId).to.equal('VPN_TRUNCATED')
-    expect(review.checklists[0].revisionStr).to.equal('V0R5')
+    expect(review.checklists[0].revisionStr).to.equal('V2R5')
   })
 
   it('A multi-stig Checklist array testing for correct benchmarkId and revisionStr', async () => {
@@ -97,15 +97,15 @@ describe('CKLB Checklist tests', () => {
     const expectedChecklists = [
       {
         benchmarkId: 'RHEL_8_TRUNCATED',
-        revisionStr: 'V0R12'
+        revisionStr: 'V1R12'
       },
       {
         benchmarkId: 'RHEL_9_TRUNCATED',
-        revisionStr: 'V0R1'
+        revisionStr: 'V1R1'
       },
       {
         benchmarkId: 'VPN_TRUNCATED',
-        revisionStr: 'V0R5'
+        revisionStr: 'V2R5'
       }
     ]
 

--- a/test/cklb-tests/CKLBRevisionStr.test.js
+++ b/test/cklb-tests/CKLBRevisionStr.test.js
@@ -1,0 +1,94 @@
+import chai from 'chai'
+import { reviewsFromCklb } from '../../ReviewParser.js'
+
+import fs from 'fs/promises'
+
+const expect = chai.expect
+
+// Create a helper function to read the file and generate the review object
+async function generateReviewObject (
+  filePath,
+  importOptions,
+  fieldSettings,
+  allowAccept
+) {
+  const data = await fs.readFile(filePath, 'utf8')
+  return reviewsFromCklb({
+    data,
+
+    fieldSettings,
+    allowAccept,
+    importOptions
+  })
+}
+
+describe('testing that revision strings are correctly parsed', () => {
+
+  it('Testing a v2r5 revison str is currently being returned as v2r5', async () => {
+
+    const importOptions = {
+      autoStatus: 'submitted',
+      unreviewed: 'commented',
+      unreviewedCommented: 'informational',
+      emptyDetail: 'import',
+      emptyComment: 'import',
+      allowCustom: true
+    }
+
+    const fieldSettings = {
+      detail: {
+        enabled: 'always', // not used
+        required: 'always'
+      },
+      comment: {
+        enabled: 'findings', // not used
+        required: 'optional'
+      }
+    }
+    const allowAccept = true
+
+    const filePath = './WATCHER-test-files/WATCHER/cklb/Asset_a-VPN_TRUNCATED-V2R5.cklb'
+
+    const review = await generateReviewObject(
+      filePath,
+      importOptions,
+      fieldSettings,
+      allowAccept
+    )
+    expect(review.checklists[0].revisionStr).to.eql("V2R5")
+  })
+  
+  it('Testing a v2r5 revison str is not being returned as V0R5', async () => {
+
+    const importOptions = {
+      autoStatus: 'submitted',
+      unreviewed: 'commented',
+      unreviewedCommented: 'informational',
+      emptyDetail: 'import',
+      emptyComment: 'import',
+      allowCustom: true
+    }
+
+    const fieldSettings = {
+      detail: {
+        enabled: 'always', // not used
+        required: 'always'
+      },
+      comment: {
+        enabled: 'findings', // not used
+        required: 'optional'
+      }
+    }
+    const allowAccept = true
+
+    const filePath = './WATCHER-test-files/WATCHER/cklb/Asset_a-VPN_TRUNCATED-V2R5.cklb'
+
+    const review = await generateReviewObject(
+      filePath,
+      importOptions,
+      fieldSettings,
+      allowAccept
+    )
+    expect(review.checklists[0].revisionStr).to.not.eql("V0R5")
+  })
+})


### PR DESCRIPTION
Parser was always assigning version 0 in a revision string. It now correctly parses the revision string from the data provided to the parser. 