### PR TITLE
Detect and return updated asset properties in taskObject when imported data differs from known asset properties

### DIFF
--- a/TaskObject.js
+++ b/TaskObject.js
@@ -99,6 +99,7 @@ export default class TaskObject {
     // {
     // knownAsset: false, // does the asset need to be created
     // assetProps: null, // an Asset object suitable for put/post to the API 
+    // hasUpdatedAssetProps: false, // asset props in checklist differ from existing API asset and should be updated (only relevant if knownAsset is true)
     // hasNewAssignment: false, //  are there new STIG assignments?
     // newAssignments: [], // any new assignments
     // checklists: new Map(), // the vetted result checklists, a Map() keyed by benchmarkId
@@ -146,7 +147,8 @@ export default class TaskObject {
         // This is our first encounter with this assetName, initialize Map() value
         taskAsset = {
           knownAsset: false,
-          assetProps: null, // an object suitable for put/post to the API 
+          assetProps: null, // an object suitable for put/post to the API
+          hasUpdatedAssetProps: false,
           hasNewAssignment: false,
           newAssignments: [],
           checklists: new Map(), // the vetted result checklists
@@ -179,6 +181,31 @@ export default class TaskObject {
       }
       // add any parsedResult.sourceRef to this asset's sourceRefs
       parsedResult.sourceRef !== undefined && taskAsset.sourceRefs.push(parsedResult.sourceRef)
+
+      // For known assets, merge any populated target properties that differ from the API asset
+      if (taskAsset.knownAsset) {
+        const target = parsedResult.target
+        const props = taskAsset.assetProps
+        // String fields: only update if parsed value is populated (truthy = non-null, non-empty)
+        for (const field of ['ip', 'fqdn', 'mac']) {
+          if (target[field] && target[field] !== props[field]) {
+            props[field] = target[field]
+            taskAsset.hasUpdatedAssetProps = true
+          }
+        }
+        // noncomputing: only update when parsed value is true; false is the parser default
+        // for formats like XCCDF that don't specify it, so treat false as "not populated"
+        if (target.noncomputing && target.noncomputing !== props.noncomputing) {
+          props.noncomputing = target.noncomputing
+          taskAsset.hasUpdatedAssetProps = true
+        }
+        // metadata.cklRole: only update if parsed value is populated
+        if (target.metadata?.cklRole && target.metadata.cklRole !== props.metadata?.cklRole) {
+          if (!props.metadata) props.metadata = {}
+          props.metadata.cklRole = target.metadata.cklRole
+          taskAsset.hasUpdatedAssetProps = true
+        }
+      }
 
       // Helper functions
       const stigIsInstalled = ({ benchmarkId, revisionStr }) => {

--- a/TaskObject.js
+++ b/TaskObject.js
@@ -199,11 +199,13 @@ export default class TaskObject {
           props.noncomputing = target.noncomputing
           taskAsset.hasUpdatedAssetProps = true
         }
-        // metadata.cklRole: only update if parsed value is populated
-        if (target.metadata?.cklRole && target.metadata.cklRole !== props.metadata?.cklRole) {
-          if (!props.metadata) props.metadata = {}
-          props.metadata.cklRole = target.metadata.cklRole
-          taskAsset.hasUpdatedAssetProps = true
+        // metadata.cklRole and metadata.cklTechArea: only update if parsed value is populated
+        for (const field of ['cklRole', 'cklTechArea']) {
+          if (target.metadata?.[field] && target.metadata[field] !== props.metadata?.[field]) {
+            if (!props.metadata) props.metadata = {}
+            props.metadata[field] = target.metadata[field]
+            taskAsset.hasUpdatedAssetProps = true
+          }
         }
       }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -193,16 +193,6 @@ interface ParserParams {
   sourceRef: any;
 }
 
-interface ImportOptions {
-  autoStatus: AutoStatus;
-  unreviewed: Unreviewed;
-  unreviewedCommented: UnreviewedCommented;
-  emptyDetail: EmptyCommentDetailType;
-  emptyComment: EmptyCommentDetailType;
-  allowCustom: boolean;
-  updateAssetProps?: boolean;
-}
-
 interface ScapBenchmarkMap {
   [key: string]: string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,6 +133,7 @@ interface TaskAssetValue {
     checklists: Map<string, TaskAssetChecklist[]>;
     checklistsIgnored: TaskAssetChecklist[];
     hasNewAssignment: boolean;
+    hasUpdatedAssetProps: boolean;
     knownAsset: boolean;
     newAssignments: string[];
     sourceRefs: any[];
@@ -181,6 +182,7 @@ interface ImportOptions {
   emptyDetail: EmptyCommentDetailType;
   emptyComment: EmptyCommentDetailType;
   allowCustom: boolean;
+  updateAssetProps?: boolean;
 }
 
 interface ParserParams {
@@ -198,6 +200,7 @@ interface ImportOptions {
   emptyDetail: EmptyCommentDetailType;
   emptyComment: EmptyCommentDetailType;
   allowCustom: boolean;
+  updateAssetProps?: boolean;
 }
 
 interface ScapBenchmarkMap {

--- a/test/watcher-logic/taskObjectUpdatedAssetProps.test.js
+++ b/test/watcher-logic/taskObjectUpdatedAssetProps.test.js
@@ -333,7 +333,7 @@ describe('TaskObject hasUpdatedAssetProps tests', () => {
     })
   })
 
-  describe('metadata.cklRole merge', () => {
+  describe('metadata.cklRole and metadata.cklTechArea merge', () => {
     it('should merge cklRole when parsed value is populated and differs', () => {
       const apiAssets = [{
         assetId: '1',
@@ -398,6 +398,72 @@ describe('TaskObject hasUpdatedAssetProps tests', () => {
       const taskAsset = to.taskAssets.get('testasset')
       expect(taskAsset.hasUpdatedAssetProps).to.be.false
       expect(taskAsset.assetProps.metadata.cklRole).to.equal('Member Server')
+    })
+
+    it('should merge cklTechArea when parsed value is populated and differs', () => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: {},
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: false,
+          metadata: { cklTechArea: 'Database' },
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      const taskAsset = to.taskAssets.get('testasset')
+      expect(taskAsset.hasUpdatedAssetProps).to.be.true
+      expect(taskAsset.assetProps.metadata.cklTechArea).to.equal('Database')
+    })
+
+    it('should not overwrite cklTechArea when parsed value is empty', () => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: { cklTechArea: 'Web Review' },
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: false,
+          metadata: {},
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      const taskAsset = to.taskAssets.get('testasset')
+      expect(taskAsset.hasUpdatedAssetProps).to.be.false
+      expect(taskAsset.assetProps.metadata.cklTechArea).to.equal('Web Review')
     })
   })
 })

--- a/test/watcher-logic/taskObjectUpdatedAssetProps.test.js
+++ b/test/watcher-logic/taskObjectUpdatedAssetProps.test.js
@@ -1,0 +1,403 @@
+import chai from 'chai'
+import TaskObject from '../../TaskObject.js'
+const expect = chai.expect
+
+// Minimal checklist template to reuse across tests
+const makeChecklist = (benchmarkId = 'VPN_SRG_TEST') => ({
+  benchmarkId,
+  revisionStr: 'V1R1',
+  reviews: [{
+    ruleId: 'SV-106179r1_rule',
+    result: 'pass',
+    detail: 'test',
+    comment: null,
+    resultEngine: null,
+    status: 'saved',
+  }],
+  stats: {
+    pass: 1, fail: 0, notapplicable: 0, notchecked: 0,
+    notselected: 0, informational: 0, error: 0, fixed: 0, unknown: 0,
+  },
+})
+
+const apiStigs = [{
+  benchmarkId: 'VPN_SRG_TEST',
+  title: 'VPN SRG TEST',
+  status: 'accepted',
+  lastRevisionStr: 'V1R1',
+  lastRevisionDate: '2019-07-19',
+  ruleCount: 81,
+  revisionStrs: ['V1R1'],
+  collectionIds: ['1'],
+}]
+
+const options = {
+  collectionId: '1',
+  createObjects: true,
+  strictRevisionCheck: false,
+}
+
+describe('TaskObject hasUpdatedAssetProps tests', () => {
+
+  describe('known asset with differing populated string fields', () => {
+    let taskAsset
+    before(() => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: {},
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: '10.0.0.1',
+          fqdn: 'test.example.com',
+          mac: '00:11:22:33:44:55',
+          noncomputing: false,
+          metadata: {},
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      taskAsset = to.taskAssets.get('testasset')
+    })
+
+    it('should set hasUpdatedAssetProps to true', () => {
+      expect(taskAsset.hasUpdatedAssetProps).to.be.true
+    })
+    it('should merge ip into assetProps', () => {
+      expect(taskAsset.assetProps.ip).to.equal('10.0.0.1')
+    })
+    it('should merge fqdn into assetProps', () => {
+      expect(taskAsset.assetProps.fqdn).to.equal('test.example.com')
+    })
+    it('should merge mac into assetProps', () => {
+      expect(taskAsset.assetProps.mac).to.equal('00:11:22:33:44:55')
+    })
+  })
+
+  describe('known asset with null/empty parsed fields', () => {
+    let taskAsset
+    before(() => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: 'existing.example.com',
+        description: '',
+        ip: '192.168.1.1',
+        mac: 'AA:BB:CC:DD:EE:FF',
+        noncomputing: true,
+        metadata: { cklRole: 'Domain Controller' },
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: false,
+          metadata: {},
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      taskAsset = to.taskAssets.get('testasset')
+    })
+
+    it('should set hasUpdatedAssetProps to false', () => {
+      expect(taskAsset.hasUpdatedAssetProps).to.be.false
+    })
+    it('should not change ip', () => {
+      expect(taskAsset.assetProps.ip).to.equal('192.168.1.1')
+    })
+    it('should not change fqdn', () => {
+      expect(taskAsset.assetProps.fqdn).to.equal('existing.example.com')
+    })
+    it('should not change mac', () => {
+      expect(taskAsset.assetProps.mac).to.equal('AA:BB:CC:DD:EE:FF')
+    })
+    it('should not change noncomputing (false is not populated)', () => {
+      expect(taskAsset.assetProps.noncomputing).to.be.true
+    })
+    it('should not change metadata.cklRole', () => {
+      expect(taskAsset.assetProps.metadata.cklRole).to.equal('Domain Controller')
+    })
+  })
+
+  describe('known asset with matching values', () => {
+    let taskAsset
+    before(() => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: 'test.example.com',
+        description: '',
+        ip: '10.0.0.1',
+        mac: '00:11:22:33:44:55',
+        noncomputing: true,
+        metadata: { cklRole: 'Domain Controller' },
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: '10.0.0.1',
+          fqdn: 'test.example.com',
+          mac: '00:11:22:33:44:55',
+          noncomputing: true,
+          metadata: { cklRole: 'Domain Controller' },
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      taskAsset = to.taskAssets.get('testasset')
+    })
+
+    it('should set hasUpdatedAssetProps to false when values match', () => {
+      expect(taskAsset.hasUpdatedAssetProps).to.be.false
+    })
+  })
+
+  describe('new asset is unaffected by merge logic', () => {
+    let taskAsset
+    before(() => {
+      const apiAssets = []
+      const parsedResults = [{
+        target: {
+          name: 'BrandNewAsset',
+          description: null,
+          ip: '10.0.0.1',
+          fqdn: 'new.example.com',
+          mac: '00:11:22:33:44:55',
+          noncomputing: true,
+          metadata: { cklRole: 'Member Server' },
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      taskAsset = to.taskAssets.get('brandnewasset')
+    })
+
+    it('should have knownAsset false', () => {
+      expect(taskAsset.knownAsset).to.be.false
+    })
+    it('should have hasUpdatedAssetProps false', () => {
+      expect(taskAsset.hasUpdatedAssetProps).to.be.false
+    })
+  })
+
+  describe('multiple parsedResults for same known asset - last populated value wins', () => {
+    let taskAsset
+    before(() => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: {},
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [
+        {
+          target: {
+            name: 'TestAsset',
+            description: null,
+            ip: '10.0.0.1',
+            fqdn: null,
+            mac: null,
+            noncomputing: false,
+            metadata: {},
+          },
+          checklists: [makeChecklist()],
+          sourceRef: 'first.ckl',
+        },
+        {
+          target: {
+            name: 'TestAsset',
+            description: null,
+            ip: '10.0.0.2',
+            fqdn: 'updated.example.com',
+            mac: null,
+            noncomputing: false,
+            metadata: {},
+          },
+          checklists: [makeChecklist()],
+          sourceRef: 'second.ckl',
+        },
+      ]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      taskAsset = to.taskAssets.get('testasset')
+    })
+
+    it('should set hasUpdatedAssetProps to true', () => {
+      expect(taskAsset.hasUpdatedAssetProps).to.be.true
+    })
+    it('should have ip from the last parsedResult', () => {
+      expect(taskAsset.assetProps.ip).to.equal('10.0.0.2')
+    })
+    it('should have fqdn from the second parsedResult', () => {
+      expect(taskAsset.assetProps.fqdn).to.equal('updated.example.com')
+    })
+  })
+
+  describe('noncomputing only merges when parsed value is true', () => {
+    it('should update noncomputing from false to true', () => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: {},
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: true,
+          metadata: {},
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      const taskAsset = to.taskAssets.get('testasset')
+      expect(taskAsset.hasUpdatedAssetProps).to.be.true
+      expect(taskAsset.assetProps.noncomputing).to.be.true
+    })
+
+    it('should NOT update noncomputing from true to false (false is not populated)', () => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: true,
+        metadata: {},
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: false,
+          metadata: {},
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      const taskAsset = to.taskAssets.get('testasset')
+      expect(taskAsset.hasUpdatedAssetProps).to.be.false
+      expect(taskAsset.assetProps.noncomputing).to.be.true
+    })
+  })
+
+  describe('metadata.cklRole merge', () => {
+    it('should merge cklRole when parsed value is populated and differs', () => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: {},
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: false,
+          metadata: { cklRole: 'Domain Controller' },
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      const taskAsset = to.taskAssets.get('testasset')
+      expect(taskAsset.hasUpdatedAssetProps).to.be.true
+      expect(taskAsset.assetProps.metadata.cklRole).to.equal('Domain Controller')
+    })
+
+    it('should not overwrite cklRole when parsed value is empty', () => {
+      const apiAssets = [{
+        assetId: '1',
+        name: 'TestAsset',
+        fqdn: '',
+        description: '',
+        ip: '',
+        mac: '',
+        noncomputing: false,
+        metadata: { cklRole: 'Member Server' },
+        collection: { name: 'testCollection', collectionId: '1' },
+        labelIds: [],
+        stigs: [{ benchmarkId: 'VPN_SRG_TEST', revisionStr: 'V1R1', benchmarkDate: '2019-07-19', revisionPinned: false, ruleCount: 81 }],
+      }]
+      const parsedResults = [{
+        target: {
+          name: 'TestAsset',
+          description: null,
+          ip: null,
+          fqdn: null,
+          mac: null,
+          noncomputing: false,
+          metadata: {},
+        },
+        checklists: [makeChecklist()],
+        sourceRef: 'test.ckl',
+      }]
+      const to = new TaskObject({ parsedResults, apiAssets, apiStigs, options })
+      const taskAsset = to.taskAssets.get('testasset')
+      expect(taskAsset.hasUpdatedAssetProps).to.be.false
+      expect(taskAsset.assetProps.metadata.cklRole).to.equal('Member Server')
+    })
+  })
+})


### PR DESCRIPTION
This pull request enhances the asset update logic in the `TaskObject` class, specifically to better track and update asset properties when processing known assets. The main improvement is the introduction of a mechanism for detecting and applying updates to asset properties when differences are found between parsed checklist data and existing asset data.


Key changes:

**Asset property update tracking and logic:**
* Added a new `hasUpdatedAssetProps` flag to the `taskAsset` object and its documentation to indicate when asset properties have been updated and need to be sent to the API. [[1]](diffhunk://#diff-1f23f2715845aa9995706886487c9208a8ef23182b1a0d7203a37a8805e4aacaR102) [[2]](diffhunk://#diff-1f23f2715845aa9995706886487c9208a8ef23182b1a0d7203a37a8805e4aacaR151)
* Implemented logic to compare parsed checklist asset properties with existing API asset properties for known assets, updating fields such as `ip`, `fqdn`, `mac`, `noncomputing`, and metadata fields (`cklRole`, `cklTechArea`) only if the parsed values are populated and differ from the current values. The `hasUpdatedAssetProps` flag is set to `true` if any change is detected.